### PR TITLE
fix(main)!: Free functions for `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+### Fixes
+
+- Skip the extension trait, make `proc_exit::exit` the tool for `main`.
+
 ## [0.2.0] - 2020-11-21
 
 ### Fixes

--- a/src/code.rs
+++ b/src/code.rs
@@ -193,7 +193,7 @@ impl Code {
         std::process::exit(self.coerce().unwrap_or_default().raw())
     }
 
-    pub fn ok(self) -> Result<(), crate::Exit> {
+    pub fn ok(self) -> crate::ExitResult {
         if self.0 == Self::SUCCESS.0 {
             Ok(())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,15 @@
 //!     // Simple but Macro-less `main`
 //!     // - Fast compiles
 //!     // - Composable with other features
-//!     use proc_exit::ProcessExitResultExt;
-//!     run().process_exit();
+//!     let result = run();
+//!     proc_exit::exit(result);
 //! }
 //!
-//! fn run() -> Result<(), proc_exit::Exit> {
+//! fn run() -> proc_exit::ExitResult {
 //!     // Integrates directly with `std::io::Error`, returning the right exit code.
 //!     let exit_status = std::process::Command::new("true")
 //!          .status()?;
-//!     // Can pass `Command` exit codes right up
+//!     // Can pass `Command` exit codes right up, when appropriate
 //!     proc_exit::Code::from_status(exit_status).ok()?;
 //!
 //!     proc_exit::Code::SUCCESS.ok()
@@ -94,6 +94,6 @@ mod code;
 mod exit;
 
 pub use code::Code;
-pub use exit::Exit;
-pub use exit::ProcessExitResultExt;
 pub use exit::WithCodeResultExt;
+pub use exit::{exit, report};
+pub use exit::{Exit, ExitResult};


### PR DESCRIPTION
It was awkward to have an extension trait just for one function call, so
I switched it being a free function.